### PR TITLE
Ubuntu MATE 24.04 shows a ridiculously oversized United Nations flag as "System Restart Required" indicator

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,7 +78,7 @@ The Bugs
 
 * `Why does man print "gimme gimme gimme" at 00:30? <https://unix.stackexchange.com/questions/405783/why-does-man-print-gimme-gimme-gimme-at-0030>`_
 
-* `Ubuntu Mate shows an oversized cropped UN flag in the panel after a system update <https://ubuntu-mate.community/t/how-to-fix-strange-un-united-nations-flag-logo-emblem-icon-issue/27449>`_
+* `Ubuntu MATE shows an oversized cropped United Nations flag in the panel after a system update <https://ubuntu-mate.community/t/how-to-fix-strange-un-united-nations-flag-logo-emblem-icon-issue/27449>`_
 
 Other Kind-of-Similar Lists
 ---------------------------

--- a/README.rst
+++ b/README.rst
@@ -78,6 +78,8 @@ The Bugs
 
 * `Why does man print "gimme gimme gimme" at 00:30? <https://unix.stackexchange.com/questions/405783/why-does-man-print-gimme-gimme-gimme-at-0030>`_
 
+* `Ubuntu Mate shows an oversized cropped UN flag in the panel after a system update <https://ubuntu-mate.community/t/how-to-fix-strange-un-united-nations-flag-logo-emblem-icon-issue/27449>`_
+
 Other Kind-of-Similar Lists
 ---------------------------
 


### PR DESCRIPTION
I just noticed, again, that my Ubuntu MATE 24.04 installation will show a ridiculously oversized and cropped UN-flag in the top status bar after a system upgrade, looking like this:

![image](https://github.com/user-attachments/assets/d93875f2-3f4d-40bd-bb60-0613017eab92)

I had noticed it multiple times previously. When clicking on it, you get a one-element dropdown menu that says "System restart required".

I was assuming that some image files got corrupted on my system, but out of curiosity, I decided to [google "ubuntu system restart require UN flag"](https://www.google.com/search?q=ubuntu+system+restart+require+UN+flag), and to my amazement, the first google result really is a Ubuntu MATE community forum where someone posted a [question with the title](https://ubuntu-mate.community/t/how-to-fix-strange-un-united-nations-flag-logo-emblem-icon-issue/27449)
> How to fix strange UN (United Nations) flag / logo / emblem icon issue?

Turns out that the system is looking for a file called "un-reboot.png", with "un" being an abbreviation for "update notifier", while the Yaru theme that MATE comes with also defines a "un.svg" file containing the united nations flag. For some reason, the system displays that SVG instead.